### PR TITLE
Add support for different name case conventions

### DIFF
--- a/clients/cardscan-ts/README.md
+++ b/clients/cardscan-ts/README.md
@@ -26,19 +26,17 @@ yarn add @cardscan.ai/cardscan-client
 ### Usage
 
 ```typescript
-import { CardScanApi, Configuration } from "@cardscan.ai/cardscan-client";
+import { CardScanApi } from "@cardscan.ai/cardscan-client";
 
-const cardScanApi = new CardScanApi(
-  new Configuration({
-    /*
-     * By default the API will the production url if NODE_ENV is "production" and the sandbox url otherwise.
-     * You can also specify a url manually.
-     * */
-    // baseUrl: "https://api.cardscan.ai/v1",
+const cardScanApi = new CardScanApi({
+  /*
+   * By default the API will the production url if NODE_ENV is "production" and the sandbox url otherwise.
+   * You can also specify a url manually.
+   * */
+  // baseUrl: "https://api.cardscan.ai/v1",
 
-    apiKey: "<your-api-key>",
-  }),
-);
+  apiKey: "<your-api-key>",
+});
 
 const main = async () => {
   try {

--- a/templates/typescript-template/apiInner.mustache
+++ b/templates/typescript-template/apiInner.mustache
@@ -3,7 +3,8 @@
 /* eslint-disable */
 {{>licenseInfo}}
 
-import type { Configuration } from '{{apiRelativeToRoot}}configuration';
+import type { ConfigurationParameters, NameCase } from '{{apiRelativeToRoot}}configuration';
+import { Configuration } from '../configuration';
 import type { AxiosPromise, AxiosInstance, RawAxiosRequestConfig } from 'axios';
 import * as WebSocket from "ws";
 import { XMLParser } from "fast-xml-parser";
@@ -19,6 +20,7 @@ import {
   EligibilityState,
   UploadParameters,
   CardWebsocketEventTypeEnum,
+  KeysToCamelCase,
 } from "../models";
 {{#withNodeImports}}
 // URLSearchParams not necessarily used
@@ -35,7 +37,7 @@ import { DUMMY_BASE_URL, assertParamExists, setApiKeyToObject, setBasicAuthToObj
 import { BASE_PATH, COLLECTION_FORMATS, RequestArgs, BaseAPI, RequiredError, operationServerMap } from '{{apiRelativeToRoot}}base';
 {{#imports}}
 // @ts-ignore
-import { {{classname}} } from '{{apiRelativeToRoot}}{{tsModelPackage}}';
+import { {{classname}}, {{classname}}Camel } from '{{apiRelativeToRoot}}{{tsModelPackage}}';
 {{/imports}}
 {{/withSeparateModelsAndApi}}
 {{^withSeparateModelsAndApi}}
@@ -388,13 +390,14 @@ export interface {{classname}}{{operationIdCamelCase}}Request {
 export class {{classname}} extends BaseAPI implements {{classname}}Interface {
 {{/withInterfaces}}
 {{^withInterfaces}}
-export class {{classname}} extends BaseAPI {
+export class {{classname}}<TCase extends NameCase = 'snake'> extends BaseAPI {
   constructor(
-    configuration?: Configuration,
+    configuration?: ConfigurationParameters | { nameCase?: TCase },
     protected basePath: string = BASE_PATH,
     protected axios: AxiosInstance = globalAxios,
   ) {
-    super(configuration, basePath, axios);
+    super(new Configuration(configuration), basePath, axios);
+    this.configuration.nameCase = configuration.nameCase ?? "snake" as TCase;
   }
 
   /**
@@ -434,7 +437,7 @@ export class {{classname}} extends BaseAPI {
    * @param frontImage The front side image to scan. For client side code this can be a File object, for server side code this can be a Blob or a Stream.
    * @param backImage The back side image to scan. For client side code this can be a File object, for server side code this can be a Blob or a Stream.
    * */
-  public async fullScan({
+    public async fullScan({
     frontImage,
     backImage,
   }: {
@@ -453,8 +456,10 @@ export class {{classname}} extends BaseAPI {
       await this.createCard({
         enable_livescan: false,
         enable_backside_scan: Boolean(backImage),
+      }, {
+        forceOriginalCase: true
       })
-    ).data;
+    ) as CardApiResponse;
 
     this.debug(`Card created successfully: ${JSON.stringify(card)}`);
 
@@ -477,8 +482,8 @@ export class {{classname}} extends BaseAPI {
         const frontSideUploadUrlResponse = (
           await this.generateCardUploadUrl(card.card_id, 3600, {
             orientation: ScanOrientation.Front,
-          })
-        ).data;
+          }, { forceOriginalCase: true })
+        ) as GenerateCardUploadUrl200Response;
         this.debug(
           `Front side upload URL generated successfully, response: ${JSON.stringify(frontSideUploadUrlResponse)}}`,
         );
@@ -561,8 +566,7 @@ export class {{classname}} extends BaseAPI {
           this.info("Full scan completed successfully");
 
           this.debug("Fetching card details...");
-          const cardDetails = (await this.getCardById(frontSideEvent.card_id))
-            .data;
+          const cardDetails = (await this.getCardById(frontSideEvent.card_id, { forceOriginalCase: true })) as CardApiResponse;
 
           return resolve(cardDetails);
         }
@@ -571,8 +575,10 @@ export class {{classname}} extends BaseAPI {
         const backSideUploadUrlResponse = (
           await this.generateCardUploadUrl(card.card_id, 3600, {
             orientation: ScanOrientation.Back,
+          }, {
+            forceOriginalCase: true
           })
-        ).data;
+        ) as GenerateCardUploadUrl200Response;
 
         const formDataBack = this.cardFormDataFactory(
           backImage,
@@ -647,7 +653,7 @@ export class {{classname}} extends BaseAPI {
         this.info("Full scan completed successfully");
         this.debug("Fetching card details...");
 
-        const cardDetails = (await this.getCardById(event.card_id)).data;
+        const cardDetails = (await this.getCardById(event.card_id, { forceOriginalCase: true })) as CardApiResponse;
         resolve(cardDetails);
       });
     });
@@ -710,8 +716,10 @@ export class {{classname}} extends BaseAPI {
             await this.createEligibility({
               card_id: cardId,
               eligibility,
+            }, {
+              forceOriginalCase: true
             })
-          ).data;
+          ) as EligibilityApiResponse;
 
           this.debug(
             `Eligibility created successfully: ${JSON.stringify(response)}`,
@@ -790,14 +798,27 @@ export class {{classname}} extends BaseAPI {
     }
     {{/useSingleRequestParameter}}
     {{^useSingleRequestParameter}}
-    public {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{#isEnum}}{{{datatypeWithEnum}}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{#isNullable}} | null{{/isNullable}}{{/isEnum}}, {{/allParams}}options?: RawAxiosRequestConfig) {
-        return {{classname}}Fp(this.configuration).{{nickname}}({{#allParams}}{{paramName}}, {{/allParams}}options).then((request) => request(this.axios, this.basePath));
+    public async {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{#isEnum}}{{{datatypeWithEnum}}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{#isNullable}} | null{{/isNullable}}{{/isEnum}}, {{/allParams}}options?: RawAxiosRequestConfig & { forceOriginalCase?: boolean } ) {
+        let data = await {{classname}}Fp(this.configuration).{{nickname}}({{#allParams}}{{paramName}}, {{/allParams}}options).then((request) => request(this.axios, this.basePath)).then(r => r.data);
+
+        if (this.configuration.nameCase === 'camel' && !options.forceOriginalCase) {
+          data = this.toCamelCase<typeof data>(data);
+        }
+
+        return data as TCase extends 'snake' ? typeof data : TCase extends 'camel' ? KeysToCamelCase<typeof data> : never;
     }
     {{/useSingleRequestParameter}}
     {{^-last}}
 
     {{/-last}}
     {{/operation}}
+
+    private toCamelCase = <T>(obj: any): T => {
+        return Object.keys(obj).reduce((acc, key) => {
+            const camelKey = key.replace(/_([a-z])/g, (g) => g[1].toUpperCase());
+            return { ...acc, [camelKey]: obj[key] };
+        }, {}) as T;
+    }
 }
 {{/operations}}
 

--- a/templates/typescript-template/configuration.mustache
+++ b/templates/typescript-template/configuration.mustache
@@ -6,6 +6,8 @@ import * as winston from "winston";
 
 export type LogLevels = "debug" | "info" | "warn" | "error";
 
+export type NameCase = "snake" | "camel";
+
 export interface ConfigurationParameters {
   apiKey?:
     | string
@@ -27,6 +29,7 @@ export interface ConfigurationParameters {
   environment?: "sandbox" | "production";
   debug?: boolean;
   logging?: LogLevels;
+  nameCase?: NameCase;
 }
 
 export class Configuration {
@@ -110,6 +113,8 @@ export class Configuration {
    * */
   logging?: LogLevels;
 
+  nameCase?: NameCase;
+
   private logger: winston.Logger;
 
   constructor(param: ConfigurationParameters) {
@@ -123,6 +128,7 @@ export class Configuration {
     this.formDataCtor = param.formDataCtor;
     this.environment = param.environment;
     this.logging = param.logging;
+    this.nameCase = param.nameCase;
 
     if (!this.basePath) {
       if (this.environment === "sandbox") {

--- a/templates/typescript-template/modelGeneric.mustache
+++ b/templates/typescript-template/modelGeneric.mustache
@@ -1,3 +1,5 @@
+import { KeysToCamelCase } from "./";
+
 /**
  * {{{description}}}
  * @export
@@ -60,3 +62,5 @@ export type {{enumName}} = typeof {{enumName}}[keyof typeof {{enumName}}];
 {{/isEnum}}
 {{/vars}}
 {{/hasEnums}}
+
+export type {{classname}}Camel = KeysToCamelCase<{{classname}}>;

--- a/templates/typescript-template/modelIndex.mustache
+++ b/templates/typescript-template/modelIndex.mustache
@@ -1,2 +1,10 @@
 {{#models}}{{#model}}export * from './{{classFilename}}';{{/model}}
 {{/models}}
+
+export type CamelCase<S extends string> = S extends `${infer P1}_${infer P2}${infer P3}`
+  ? `${Lowercase<P1>}${Uppercase<P2>}${CamelCase<P3>}`
+  : Lowercase<S>
+
+export type KeysToCamelCase<T> = {
+    [K in keyof T as CamelCase<string &K>]: T[K] extends {} ? KeysToCamelCase<T[K]> : T[K]
+}


### PR DESCRIPTION
Add option to typescript client configuration to receive response objects in either camelCase or snake_case (original)

### Note
This introduces a breaking change: The `CardScanApi` class receives an object with the configuration parameters instead of an instance of the `Configuration` class