### PR TITLE
Do not format workflow files

### DIFF
--- a/.github/workflows/publish-dart-ci.yml
+++ b/.github/workflows/publish-dart-ci.yml
@@ -3,7 +3,8 @@ name: Publish Package to pub.dev
 on:
   workflow_dispatch:
   push:
-    tags: dart-v*
+    tags:
+      - 'dart-v*'
 
 jobs:
   publish-dart-package:

--- a/.github/workflows/publish-npm-ci.yml
+++ b/.github/workflows/publish-npm-ci.yml
@@ -3,7 +3,8 @@ name: Publish Package to npm
 on:
   workflow_dispatch:
   push:
-    tags: ts-v*
+    tags:
+      - 'ts-v*'
 
 jobs:
   publish-npm-package:

--- a/.github/workflows/publish-python-ci.yml
+++ b/.github/workflows/publish-python-ci.yml
@@ -3,7 +3,8 @@ name: Publish Package to PyPI
 on:
   workflow_dispatch:
   push:
-    tags: py-v*
+    tags:
+      - 'py-v*'
 
 jobs:
   publish-python-package:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,7 @@ repos:
   hooks:
   - id: pretty-format-yaml
     args: [--autofix, --indent, '2']
+    exclude: .github/
 - repo: https://github.com/python-openapi/openapi-spec-validator
   rev: master
   hooks:


### PR DESCRIPTION
The yaml formatter pre-commit hook was removing the quotes around the tag filter pattern